### PR TITLE
Add HTTP server inference option

### DIFF
--- a/skyrl-train/docs/configuration/config.rst
+++ b/skyrl-train/docs/configuration/config.rst
@@ -412,6 +412,9 @@ Inference Engine Placement Configuration
 - ``generator.run_engines_locally``: Whether to use local inference engines. If ``true``, the inference engine will be initialized during the training run in the current Ray cluster. We use one Ray actor per inference replica and communication will happen via Ray object store.  If set to ``false``, then the generator expects a list of remote urls and communication will happen over HTTP.
 - ``generator.num_inference_engines``: Number of inference engines to use. If ``run_engines_locally`` is ``false``, then this number should match the number of remote urls.
 - ``generator.remote_inference_engine_urls``: List of remote urls to use. Applicable only when ``run_engines_locally`` is ``false``.
+- ``generator.use_http_server_inference_engine_client``: When ``true``, launch an OpenAI-compatible HTTP server for the inference engine client and send requests via this server.
+- ``generator.http_server_inference_engine_client_host``: Host for the local HTTP server.
+- ``generator.http_server_inference_engine_client_port``: Port for the local HTTP server.
 
 For more details on how different placement options work, please refer to the :doc:`placement guide <placement>`.
 

--- a/skyrl-train/skyrl_train/config/ppo_base_config.yaml
+++ b/skyrl-train/skyrl_train/config/ppo_base_config.yaml
@@ -159,7 +159,10 @@ generator:
   gpu_memory_utilization: 0.8
   max_num_seqs: 1024
   remote_inference_engine_urls: ["127.0.0.1:8001"]
-  max_turns: 1 
+  use_http_server_inference_engine_client: false
+  http_server_inference_engine_client_host: "127.0.0.1"
+  http_server_inference_engine_client_port: 8000
+  max_turns: 1
 
   override_existing_update_group: "auto" # "auto", "enable", "disable"
   # sampling params for generation phase


### PR DESCRIPTION
## Summary
- add config flags for launching HTTP server for inference engine client
- document the new generator options
- support launching a local OpenAI-compatible server in `SkyRLGymGenerator`
- use AsyncOpenAI requests when HTTP server mode is enabled

## Testing
- `pre-commit run --files skyrl-train/skyrl_train/config/ppo_base_config.yaml skyrl-train/docs/configuration/config.rst skyrl-train/skyrl_train/generators/skyrl_gym_generator.py`
- `bash skyrl-train/examples/gsm8k/run_gsm8k.sh` *(fails: Extra `vllm` is not defined in the project's `optional-dependencies` table)*

------
https://chatgpt.com/codex/tasks/task_e_687a920734108333b9ecde62babaa5a9