### PR TITLE
[TBenchGenreator] Make agent loop robust against sandboxes errors by removing while True

### DIFF
--- a/skyrl-train/examples/terminal_bench/terminal_bench_generator.py
+++ b/skyrl-train/examples/terminal_bench/terminal_bench_generator.py
@@ -1,7 +1,8 @@
 import asyncio
 from dataclasses import dataclass
 from typing import List
-from skyrl_train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput
+from loguru import logger
+from skyrl_train.generators.base import GeneratorInterface, GeneratorInput, GeneratorOutput, TrajectoryID
 from skyrl_train.generators.utils import get_rollout_metrics
 from skyrl_train.inference_engines.inference_engine_client import InferenceEngineClient
 from skyrl_train.inference_engines.base import ConversationType
@@ -12,6 +13,9 @@ from sandboxes.models.environment_type import EnvironmentType
 from sandboxes.models.agent.name import AgentName
 from sandboxes.trial.trial import Trial
 
+# We have N retries for each trial, if one of the rollout (out of n_samples_per_prompt) fails
+# after N attemptes, we skip this prompt altogether.
+MAX_NUM_RETRIES_PER_TRIAL = 2
 
 @dataclass
 class TerminalBenchAgentOutput:
@@ -20,6 +24,7 @@ class TerminalBenchAgentOutput:
     stop_reason: str
     loss_mask: List[int]
     prompt_ids: List[int]
+    trajectory_id: TrajectoryID
 
 
 class TerminalBenchGenerator(GeneratorInterface):
@@ -49,23 +54,48 @@ class TerminalBenchGenerator(GeneratorInterface):
 
     async def generate(self, input_batch: GeneratorInput) -> GeneratorOutput:
         tasks = []
-        for prompt in input_batch["prompts"]:
+        for i in range(len(input_batch["prompts"])):
             tasks.append(
                 self.terminal_bench_agent_loop(
-                    prompt=prompt,
+                    prompt=input_batch["prompts"][i],
+                    trajectory_id=input_batch["trajectory_ids"][i],
                 )
             )
 
-        all_outputs = await asyncio.gather(*tasks)
+        all_outputs: List[TerminalBenchAgentOutput] = await asyncio.gather(*tasks)
 
-        responses = [output.response_ids for output in all_outputs]
-        rewards = [output.reward for output in all_outputs]
-        rollout_metrics = get_rollout_metrics(responses, rewards)
+        # For a group of trajectories (n_samples_per_prompt trajectories for the same prompt), if one
+        # of the trajectories fails, we skip the entire group. We also skip the group for rollout metric aggregation
+        failed_instance_ids = set()
+        num_failed_trajectories = 0  # per-trajectory, rather than per-instance
+        successful_outputs: List[TerminalBenchAgentOutput] = []  # only for metrics purpose
+        for output in all_outputs:
+            if output.stop_reason == "error":
+                failed_instance_ids.add(output.trajectory_id.instance_id)
+                num_failed_trajectories += 1
+
+        for output in all_outputs:
+            if output.trajectory_id.instance_id in failed_instance_ids:
+                output.response_ids = [0]
+                output.stop_reason = "error"
+                output.loss_mask = [0]
+                output.prompt_ids = [0]
+                output.reward = 0
+            else:
+                successful_outputs.append(output)
+
+        # Calculate rollout metrics for successful outputs
+        rollout_metrics = get_rollout_metrics(
+            [output.response_ids for output in successful_outputs], 
+            [output.reward for output in successful_outputs],
+        )
+        rollout_metrics["generate/num_failed_instances"] = len(failed_instance_ids)
+        rollout_metrics["generate/num_failed_trajectories"] = num_failed_trajectories
 
         generator_output: GeneratorOutput = {
             "prompt_token_ids": [output.prompt_ids for output in all_outputs],
-            "response_ids": responses,
-            "rewards": rewards,
+            "response_ids": [output.response_ids for output in all_outputs],
+            "rewards": [output.reward for output in all_outputs],
             "loss_masks": [output.loss_mask for output in all_outputs],
             "stop_reasons": [output.stop_reason for output in all_outputs],
             "rollout_metrics": rollout_metrics,
@@ -77,6 +107,7 @@ class TerminalBenchGenerator(GeneratorInterface):
     async def terminal_bench_agent_loop(
         self,
         prompt: ConversationType,
+        trajectory_id: TrajectoryID,
     ) -> TerminalBenchAgentOutput:
         """
         Run a single terminal_bench agent.
@@ -107,22 +138,37 @@ class TerminalBenchGenerator(GeneratorInterface):
 
         trial = Trial(trial_config)
         # Run the trial
-        while True:
+        successful = False
+        for i in range(MAX_NUM_RETRIES_PER_TRIAL):
+            prefix = f"Trajectory {trajectory_id} attempt {i+1}/{MAX_NUM_RETRIES_PER_TRIAL}"
             try:
                 results = await trial.run()
                 if not results.verifier_result:
-                    print(f"[WARNING] Exception info: {results.exception_info}")
+                    logger.warning(f"{prefix} failed: Exception info: {results.exception_info}")
                     continue
                 reward = results.verifier_result.reward
-                print(f"Results: {results.agent_result.metadata}")
+                logger.info(f"{prefix} successful: Results: {results.agent_result.metadata}")
                 chat_history = results.agent_result.metadata['all_messages']
                 if len(chat_history) > 0:
+                    successful = True
                     break
                 else:
-                    print(f"[WARNING] Agent {self.agent_name} did not return a response")
+                    logger.warning(f"{prefix} failed: Agent {self.agent_name} did not return a response")
             except Exception as e:
-                print(f"Error running trial: {e}")
+                logger.warning(f"{prefix} failed: Error running trial: {e}")
                 continue
+
+        if not successful:
+            # We make loss mask 0 so it does not contribute to model updates
+            logger.warning(f"Trajectory {trajectory_id} failed after {MAX_NUM_RETRIES_PER_TRIAL} attempts, will set loss mask to [0].")
+            return TerminalBenchAgentOutput(
+                response_ids=[0],
+                reward=0,
+                stop_reason="error",
+                loss_mask=[0],
+                prompt_ids=[0],
+                trajectory_id=trajectory_id,
+            )
 
         # Use the first message as the prompt
         prompt = [chat_history[0]]
@@ -171,4 +217,5 @@ class TerminalBenchGenerator(GeneratorInterface):
             stop_reason=stop_reason,
             loss_mask=loss_mask,
             prompt_ids=prompt_ids,
+            trajectory_id=trajectory_id,
         )


### PR DESCRIPTION
Before this PR, we will stall on failing sandboxes in this while loop, where the log can be the following indefinitely and stall training completely (below is from the [non-cleaned version of NL2Bash](https://huggingface.co/datasets/DCAgent/nl2bash-verified))

```
[36m(skyrl_entrypoint pid=503115)[0m [WARNING] Exception info: exception_type='DaytonaError' exception_message='Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox 13a4546e-1957-4730-a1e3-d9a8f8b0553f failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist' exception_traceback='Traceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/sandbox.py", line 318, in wait_for_sandbox_start\n    raise DaytonaError(err_msg)\ndaytona.common.errors.DaytonaError: Sandbox 13a4546e-1957-4730-a1e3-d9a8f8b0553f failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 348, in create\n    return await self._create(params, timeout=timeout, on_snapshot_create_logs=on_snapshot_create_logs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 462, in _create\n    await sandbox.wait_for_sandbox_start(timeout=max(0.001, timeout - time_elapsed) if timeout else timeout)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failure during waiting for sandbox to start: Sandbox 13a4546e-1957-4730-a1e3-d9a8f8b0553f failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 334, in run\n    await self._setup_environment()\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 172, in _setup_environment\n    await self._start_environment_with_retry()\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>\n    self._add_action_func(lambda rs: rs.outcome.result())\n                                     ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 184, in _start_environment_with_retry\n    await asyncio.wait_for(\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 127, in start\n    await self._create_sandbox(params=params)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 420, in exc_check\n    raise retry_exc.reraise()\n          ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 187, in reraise\n    raise self.last_attempt.result()\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 91, in _create_sandbox\n    self._sandbox = await self._daytona.create(params=params, timeout=600)\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox 13a4546e-1957-4730-a1e3-d9a8f8b0553f failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n' occurred_at=datetime.datetime(2025, 11, 18, 5, 23, 30, 557571)
[36m(skyrl_entrypoint pid=503115)[0m Sandbox not found. Please build the environment first.
[36m(skyrl_entrypoint pid=503115)[0m [WARNING] Exception info: exception_type='DaytonaError' exception_message='Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox 918ef8b0-3479-40fb-b095-a815dd59395c failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist' exception_traceback='Traceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/sandbox.py", line 318, in wait_for_sandbox_start\n    raise DaytonaError(err_msg)\ndaytona.common.errors.DaytonaError: Sandbox 918ef8b0-3479-40fb-b095-a815dd59395c failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 348, in create\n    return await self._create(params, timeout=timeout, on_snapshot_create_logs=on_snapshot_create_logs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 462, in _create\n    await sandbox.wait_for_sandbox_start(timeout=max(0.001, timeout - time_elapsed) if timeout else timeout)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failure during waiting for sandbox to start: Sandbox 918ef8b0-3479-40fb-b095-a815dd59395c failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 334, in run\n    await self._setup_environment()\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 172, in _setup_environment\n    await self._start_environment_with_retry()\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>\n    self._add_action_func(lambda rs: rs.outcome.result())\n                                     ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 184, in _start_environment_with_retry\n    await asyncio.wait_for(\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 127, in start\n    await self._create_sandbox(params=params)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 420, in exc_check\n    raise retry_exc.reraise()\n          ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 187, in reraise\n    raise self.last_attempt.result()\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 91, in _create_sandbox\n    self._sandbox = await self._daytona.create(params=params, timeout=600)\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox 918ef8b0-3479-40fb-b095-a815dd59395c failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n' occurred_at=datetime.datetime(2025, 11, 18, 5, 23, 31, 814435)
[36m(skyrl_entrypoint pid=503115)[0m Sandbox not found. Please build the environment first.
```

After this PR, if a single trajectory fails over N (currently 2) times, we set `response_ids=[0]` and `loss_masks=[0]` so it does not contribute to the model update. If a single trajectory fails in a group (of `n_samples_per_prompt` trajectories), we set entire group's loss masks to zeros -- so we skip the example altogether. We add metrics `generate/num_failed_instances` and `generate/num_failed_trajectories`.

After the PR, the above failures become:

```
TrajectoryID(instance_id='9048', repetition_id=1) attempt 2/2 failed: Exception info: exception_type='DaytonaError' exception_message='Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox 803b3596-e9e6-4265-87c7-b8a4e64aa7bc failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist' exception_traceback='Traceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/sandbox.py", line 318, in wait_for_sandbox_start\n    raise DaytonaError(err_msg)\ndaytona.common.errors.DaytonaError: Sandbox 803b3596-e9e6-4265-87c7-b8a4e64aa7bc failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 348, in create\n    return await self._create(params, timeout=timeout, on_snapshot_create_logs=on_snapshot_create_logs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 462, in _create\n    await sandbox.wait_for_sandbox_start(timeout=max(0.001, timeout - time_elapsed) if timeout else timeout)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failure during waiting for sandbox to start: Sandbox 803b3596-e9e6-4265-87c7-b8a4e64aa7bc failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 334, in run\n    await self._setup_environment()\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 172, in _setup_environment\n    await self._start_environment_with_retry()\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>\n    self._add_action_func(lambda rs: rs.outcome.result())\n                                     ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 184, in _start_environment_with_retry\n    await asyncio.wait_for(\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 127, in start\n    await self._create_sandbox(params=params)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 420, in exc_check\n    raise retry_exc.reraise()\n          ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 187, in reraise\n    raise self.last_attempt.result()\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 91, in _create_sandbox\n    self._sandbox = await self._daytona.create(params=params, timeout=600)\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox 803b3596-e9e6-4265-87c7-b8a4e64aa7bc failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n' occurred_at=datetime.datetime(2025, 11, 19, 0, 13, 22, 107652)[0m
TrajectoryID(instance_id='9048', repetition_id=1) failed after 2 attempts, will set loss mask to [0].[0m
TrajectoryID(instance_id='9048', repetition_id=0) attempt 2/2 failed: Exception info: exception_type='DaytonaError' exception_message='Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox b18c649d-966b-44b3-ad3d-52cfb0605663 failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist' exception_traceback='Traceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/sandbox.py", line 318, in wait_for_sandbox_start\n    raise DaytonaError(err_msg)\ndaytona.common.errors.DaytonaError: Sandbox b18c649d-966b-44b3-ad3d-52cfb0605663 failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 44, in async_wrapper\n    return await func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 348, in create\n    return await self._create(params, timeout=timeout, on_snapshot_create_logs=on_snapshot_create_logs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/timeout.py", line 53, in async_wrapper\n    return await asyncio.wait_for(func(*args, **kwargs), timeout)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_async/daytona.py", line 462, in _create\n    await sandbox.wait_for_sandbox_start(timeout=max(0.001, timeout - time_elapsed) if timeout else timeout)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failure during waiting for sandbox to start: Sandbox b18c649d-966b-44b3-ad3d-52cfb0605663 failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 334, in run\n    await self._setup_environment()\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 172, in _setup_environment\n    await self._start_environment_with_retry()\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 400, in <lambda>\n    self._add_action_func(lambda rs: rs.outcome.result())\n                                     ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/trial/trial.py", line 184, in _start_environment_with_retry\n    await asyncio.wait_for(\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/asyncio/tasks.py", line 520, in wait_for\n    return await fut\n           ^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 127, in start\n    await self._create_sandbox(params=params)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped\n    return await copy(fn, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__\n    do = await self.iter(retry_state=retry_state)\n         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 153, in iter\n    result = await action(retry_state)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/_utils.py", line 99, in inner\n    return call(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 420, in exc_check\n    raise retry_exc.reraise()\n          ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/__init__.py", line 187, in reraise\n    raise self.last_attempt.result()\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 449, in result\n    return self.__get_result()\n           ^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result\n    raise self._exception\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__\n    result = await fn(*args, **kwargs)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/dcagent-workspace/harbor/src/sandboxes/environments/daytona.py", line 91, in _create_sandbox\n    self._sandbox = await self._daytona.create(params=params, timeout=600)\n                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 46, in async_wrapper\n    process_n_raise_exception(e)\n  File "/home/ec2-user/miniconda3/envs/dcagent/lib/python3.12/site-packages/daytona/_utils/errors.py", line 36, in process_n_raise_exception\n    raise DaytonaError(msg)  # pylint: disable=raise-missing-from\n    ^^^^^^^^^^^^^^^^^^^^^^^\ndaytona.common.errors.DaytonaError: Failed to create sandbox: Failure during waiting for sandbox to start: Sandbox b18c649d-966b-44b3-ad3d-52cfb0605663 failed to start with state: SandboxState.BUILD_FAILED, error reason: COPY failed: file not found in build context or excluded by .dockerignore: stat seeds/: file does not exist\n' occurred_at=datetime.datetime(2025, 11, 19, 0, 13, 22, 147671)[0m
TrajectoryID(instance_id='9048', repetition_id=0) failed after 2 attempts, will set loss mask to [0].[0m
```

With the metrics logged
```
[36m(skyrl_entrypoint pid=2068867)[0m  'generate/num_failed_instances': 1,
[36m(skyrl_entrypoint pid=2068867)[0m  'generate/num_failed_trajectories': 2,
```

Note that we do not include these examples for rollout metrics aggregation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce bounded retries, trajectory-aware failure grouping, and success-only rollout metrics with new failure counters and logging in the TerminalBench generator.
> 
> - **TerminalBench generator**:
>   - Add bounded retry logic (`MAX_NUM_RETRIES_PER_TRIAL`) and remove infinite loop; replace prints with `loguru` logging.
>   - Accept and propagate `trajectory_ids` to `terminal_bench_agent_loop`; extend `TerminalBenchAgentOutput` with `trajectory_id`.
>   - Failure handling: if any trajectory in an instance group fails, zero out the entire group's `response_ids`, `loss_mask`, `prompt_ids`, and `reward`; mark stop reason as `error`.
>   - Metrics: compute rollout metrics only from successful outputs; add `generate/num_failed_instances` and `generate/num_failed_trajectories`.
>   - Output assembly updated to use per-output fields and new failure handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41cb864cea028e405c30f36b137a879f9e5ad21b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->